### PR TITLE
ci: tests + multi-arch build gate

### DIFF
--- a/.github/workflows/ci-multiarch.yml
+++ b/.github/workflows/ci-multiarch.yml
@@ -1,0 +1,96 @@
+name: CI (Tests + Multi-Arch Docker Build)
+
+on:
+  push:
+    branches: [ main, "**" ]
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/persona-lab-api
+
+jobs:
+  unit-tests:
+    name: Unit tests (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -q
+
+  docker-build:
+    name: Docker build (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            short: amd64
+          - platform: linux/arm64
+            short: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR (for tags + cache)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image for ${{ matrix.platform }} (no push)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:ci-${{ matrix.short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - name: Smoke test (amd64 only)
+        if: ${{ matrix.short == 'amd64' }}
+        shell: bash
+        run: |
+          docker run -d --rm --name persona-ci -p 8001:8001 $IMAGE_NAME:ci-amd64
+          for i in {1..15}; do
+            if curl -fsS http://localhost:8001/health >/dev/null 2>&1; then
+              echo "Health OK"
+              break
+            fi
+            sleep 1
+          done
+          curl -fsS http://localhost:8001/health
+          docker rm -f persona-ci

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .


### PR DESCRIPTION
## What & Why
- Added GitHub Actions workflow for CI
- Runs Python unit tests on every push/PR
- Builds Docker images for both `linux/amd64` and `linux/arm64` using Buildx
- Added a quick amd64 smoke test hitting `/health`

## How to Verify
- Open Actions tab → see jobs: `Unit tests` + `Docker build (amd64/arm64)`
- amd64 container should start and `/health` returns OK

## Notes
- No publishing yet (compile/test gate only)
- Sets the stage for later multi-arch release workflows
