### PR TITLE
Milestone 9 — Inference Efficiency & Fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,20 @@ SAFETY_MAX_PROMPT_CHARS=4000
 # Comma-separated words to block (case-insensitive)
 SAFETY_DENYLIST=
 SAFETY_DEFAULT_LATENCY_BUDGET_MS=3500
+
+# ---- Inference Efficiency ----
+# Request timeout (seconds) for a single upstream LLM call
+LLM_TIMEOUT_SECS=8
+
+# Retry policy
+LLM_RETRY_MAX_ATTEMPTS=2            # total tries = 1 initial + 2 retries
+LLM_RETRY_BACKOFF_BASE_MS=200       # 200ms, then 400ms (exponential)
+
+# Circuit breaker window
+LLM_CB_WINDOW_SECONDS=30            # rolling window size
+LLM_CB_FAILURE_THRESHOLD=0.5        # open if >=50% of recent calls fail
+LLM_CB_MIN_CALLS=6                  # need at least 6 calls in window to evaluate
+LLM_CB_HALFOPEN_AFTER_SECONDS=15    # how long to wait before probing again
+
+# Optional latency budget (ms): if exceeded, we will allow fallback in 9B
+LLM_LATENCY_BUDGET_MS=2500

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,7 @@ LLM_CB_HALFOPEN_AFTER_SECONDS=15    # how long to wait before probing again
 
 # Optional latency budget (ms): if exceeded, we will allow fallback in 9B
 LLM_LATENCY_BUDGET_MS=2500
+
+# ---- Inference Cache ----
+LLM_CACHE_TTL_SECONDS=60
+LLM_CACHE_MAX_ENTRIES=512

--- a/app/infra/circuit_breaker.py
+++ b/app/infra/circuit_breaker.py
@@ -1,0 +1,90 @@
+# app/infra/circuit_breaker.py
+# Simple in-process circuit breaker with a rolling window.
+# Tracks successes/failures and decides whether calls should be short-circuited.
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass
+class BreakerConfig:
+    window_seconds: int = 30
+    failure_threshold: float = 0.5
+    min_calls: int = 6
+    halfopen_after_seconds: int = 15
+
+
+class CircuitState:
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreaker:
+    def __init__(self, cfg: BreakerConfig):
+        self.cfg = cfg
+        self._events = deque()  # (ts, success: bool)
+        self._lock = threading.Lock()
+        self._state = CircuitState.CLOSED
+        self._opened_at = 0.0
+
+    def _prune(self, now: float) -> None:
+        """Remove events outside the rolling window."""
+        cutoff = now - self.cfg.window_seconds
+        while self._events and self._events[0][0] < cutoff:
+            self._events.popleft()
+
+    def _stats(self, now: float) -> tuple[int, int]:
+        """Return (total_calls_in_window, failures_in_window)."""
+        self._prune(now)
+        total = len(self._events)
+        fails = sum(1 for _, ok in self._events if not ok)
+        return total, fails
+
+    def allow_request(self) -> bool:
+        """Should we attempt a call right now?"""
+        now = time.time()
+        with self._lock:
+            if self._state == CircuitState.CLOSED:
+                return True
+
+            if self._state == CircuitState.OPEN:
+                # Move to HALF_OPEN after a cooldown to allow a probe.
+                if now - self._opened_at >= self.cfg.halfopen_after_seconds:
+                    self._state = CircuitState.HALF_OPEN
+                    return True
+                return False
+
+            if self._state == CircuitState.HALF_OPEN:
+                # Allow a single probe; caller must record outcome.
+                return True
+
+            # Defensive default
+            return True
+
+    def record_success(self) -> None:
+        now = time.time()
+        with self._lock:
+            self._events.append((now, True))
+            # Any success in OPEN or HALF_OPEN closes the breaker.
+            if self._state in (CircuitState.OPEN, CircuitState.HALF_OPEN):
+                self._state = CircuitState.CLOSED
+
+    def record_failure(self) -> None:
+        now = time.time()
+        with self._lock:
+            self._events.append((now, False))
+            total, fails = self._stats(now)
+            if total >= self.cfg.min_calls and (fails / float(total)) >= self.cfg.failure_threshold:
+                # Open the breaker and start cooldown.
+                self._state = CircuitState.OPEN
+                self._opened_at = now
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            return self._state

--- a/app/infra/llm_client.py
+++ b/app/infra/llm_client.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+from typing import Any
+
+from .circuit_breaker import BreakerConfig, CircuitBreaker
+
+# ---- Config via env (with safe defaults)
+TIMEOUT_SECS = float(os.getenv("LLM_TIMEOUT_SECS", "8"))
+RETRY_MAX_ATTEMPTS = int(os.getenv("LLM_RETRY_MAX_ATTEMPTS", "2"))
+RETRY_BACKOFF_BASE_MS = int(os.getenv("LLM_RETRY_BACKOFF_BASE_MS", "200"))
+CB_WINDOW_SECONDS = int(os.getenv("LLM_CB_WINDOW_SECONDS", "30"))
+CB_FAILURE_THRESHOLD = float(os.getenv("LLM_CB_FAILURE_THRESHOLD", "0.5"))
+CB_MIN_CALLS = int(os.getenv("LLM_CB_MIN_CALLS", "6"))
+CB_HALFOPEN_AFTER_SECONDS = int(os.getenv("LLM_CB_HALFOPEN_AFTER_SECONDS", "15"))
+LATENCY_BUDGET_MS = int(os.getenv("LLM_LATENCY_BUDGET_MS", "2500"))
+
+# Only retry on truly transient errors
+TRANSIENT_ERRORS = (TimeoutError, ConnectionError)
+
+
+class CallError(Exception):
+    pass
+
+
+class LLMClient:
+    def __init__(self, fn_call_model: Callable[[dict[str, Any], float], dict[str, Any]]):
+        self._call = fn_call_model
+        self._breaker = CircuitBreaker(
+            BreakerConfig(
+                window_seconds=CB_WINDOW_SECONDS,
+                failure_threshold=CB_FAILURE_THRESHOLD,
+                min_calls=CB_MIN_CALLS,
+                halfopen_after_seconds=CB_HALFOPEN_AFTER_SECONDS,
+            )
+        )
+
+    def call(self, payload: dict[str, Any]) -> dict[str, Any]:
+        start = time.time()
+        if not self._breaker.allow_request():
+            raise CallError("circuit_open")
+
+        attempts = 0
+        backoff_ms = RETRY_BACKOFF_BASE_MS
+        last_exc: BaseException | None = None
+
+        while True:
+            attempts += 1
+            try:
+                result = self._call(payload, TIMEOUT_SECS)
+                self._breaker.record_success()
+                elapsed_ms = int((time.time() - start) * 1000)
+                return {
+                    "ok": True,
+                    "result": result,
+                    "meta": {
+                        "attempts": attempts,
+                        "elapsed_ms": elapsed_ms,
+                        "breaker_state": self._breaker.state,
+                    },
+                }
+            except TRANSIENT_ERRORS as e:
+                last_exc = e
+                self._breaker.record_failure()
+                if attempts > (1 + RETRY_MAX_ATTEMPTS):
+                    break
+                time.sleep(backoff_ms / 1000.0)
+                backoff_ms *= 2
+            except Exception as e:
+                last_exc = e
+                self._breaker.record_failure()
+                break
+
+        elapsed_ms = int((time.time() - start) * 1000)
+        return {
+            "ok": False,
+            "error": str(last_exc) if last_exc else "unknown_error",
+            "meta": {
+                "attempts": attempts,
+                "elapsed_ms": elapsed_ms,
+                "breaker_state": self._breaker.state,
+            },
+        }
+
+    def latency_budget_exceeded(self, meta: dict[str, Any]) -> bool:
+        return int(meta.get("elapsed_ms", 0)) > LATENCY_BUDGET_MS

--- a/app/infra/metrics.py
+++ b/app/infra/metrics.py
@@ -1,0 +1,89 @@
+# app/infra/metrics.py
+from __future__ import annotations
+
+import threading
+import time
+from collections import Counter, deque
+from statistics import median
+
+
+class InferenceMetrics:
+    """
+    Minimal, thread-safe in-memory metrics for inference:
+      - counters by outcome: primary | fallback_error | fallback_latency_budget | cache_hit
+      - breaker states seen (closed/open/half_open)
+      - attempts histogram (1, 2, 3, ...)
+      - latency samples (ms) per outcome + overall (capped reservoir)
+    """
+
+    def __init__(self, max_samples: int = 1000):
+        self._lock = threading.Lock()
+        self._counters = Counter()  # outcome counters
+        self._breaker = Counter()  # breaker state counters
+        self._attempts = Counter()  # attempt count distribution
+
+        self._overall_lat: deque[int] = deque(maxlen=max_samples)
+        self._by_outcome_lat: dict[str, deque[int]] = {
+            "primary": deque(maxlen=max_samples),
+            "fallback_error": deque(maxlen=max_samples),
+            "fallback_latency_budget": deque(maxlen=max_samples),
+            "cache_hit": deque(maxlen=max_samples),
+        }
+
+        self._started_at = time.time()
+
+    def record(
+        self,
+        outcome: str,
+        elapsed_ms: int | None = None,
+        breaker_state: str | None = None,
+        attempts: int | None = None,
+    ) -> None:
+        with self._lock:
+            self._counters[outcome] += 1
+            if breaker_state:
+                self._breaker[breaker_state] += 1
+            if attempts:
+                self._attempts[attempts] += 1
+            if elapsed_ms is not None:
+                self._overall_lat.append(elapsed_ms)
+                if outcome in self._by_outcome_lat:
+                    self._by_outcome_lat[outcome].append(elapsed_ms)
+
+    @staticmethod
+    def _percentile(samples: list[int], p: float) -> int | None:
+        if not samples:
+            return None
+        k = max(0, min(len(samples) - 1, int(round((p / 100.0) * (len(samples) - 1)))))
+        return sorted(samples)[k]
+
+    def _lat_summary(self, samples: deque[int]) -> dict[str, int | None]:
+        data = list(samples)
+        if not data:
+            return {"count": 0, "p50": None, "p95": None, "max": None}
+        return {
+            "count": len(data),
+            "p50": int(median(data)),
+            "p95": self._percentile(data, 95),
+            "max": max(data),
+        }
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            overall = self._lat_summary(self._overall_lat)
+            by_outcome = {k: self._lat_summary(v) for k, v in self._by_outcome_lat.items()}
+            return {
+                "as_of": int(time.time()),
+                "uptime_seconds": int(time.time() - self._started_at),
+                "counters": dict(self._counters),
+                "breaker_states": dict(self._breaker),
+                "attempts_hist": dict(self._attempts),
+                "latency": {
+                    "overall": overall,
+                    "by_outcome": by_outcome,
+                },
+            }
+
+
+# singletons are fine for this simple service
+metrics = InferenceMetrics()

--- a/app/infra/ttl_cache.py
+++ b/app/infra/ttl_cache.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import OrderedDict
+from typing import Any
+
+TTL_DEFAULT = int(os.getenv("LLM_CACHE_TTL_SECONDS", "60"))
+MAX_ENTRIES = int(os.getenv("LLM_CACHE_MAX_ENTRIES", "512"))
+
+
+class TTLCache:
+    """Simple thread-safe TTL cache with crude LRU eviction."""
+
+    def __init__(self, ttl_seconds: int = TTL_DEFAULT, max_entries: int = MAX_ENTRIES):
+        self.ttl = ttl_seconds
+        self.max = max_entries
+        self._lock = threading.Lock()
+        self._data: OrderedDict[str, tuple[float, Any]] = OrderedDict()
+
+    def _now(self) -> float:
+        return time.time()
+
+    def _evict_expired(self) -> None:
+        now = self._now()
+        # Entries are roughly in access order (we re-insert on get), but we still scan.
+        dead = []
+        for k, (ts, _) in self._data.items():
+            if now - ts > self.ttl:
+                dead.append(k)
+            else:
+                break
+        for k in dead:
+            self._data.pop(k, None)
+
+    def _evict_lru_if_needed(self) -> None:
+        while len(self._data) > self.max:
+            self._data.popitem(last=False)  # evict oldest
+
+    def get(self, key: str):
+        with self._lock:
+            self._evict_expired()
+            if key in self._data:
+                ts, val = self._data.pop(key)
+                # move to end (most-recently used)
+                self._data[key] = (ts, val)
+                return val
+            return None
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._evict_expired()
+            self._data.pop(key, None)
+            self._data[key] = (self._now(), value)
+            self._evict_lru_if_needed()

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.engagement import get_feedback_summary, get_recent_feedback, init_db, i
 from app.personas.playful import respond as playful_respond
 from app.personas.serious import respond as serious_respond
 from app.policy.ab import assign_ab, get_policy
+from app.safety.generate_router import router as generate_router
 from app.safety.router import router as safety_router
 from app.worker.personality import ASCII_LOGO, QUOTES, TIPS
 
@@ -53,6 +54,7 @@ app = FastAPI(
 )
 
 app.include_router(safety_router, prefix="/safety")
+app.include_router(generate_router, prefix="/safety")
 
 # -------------------------
 # Logging

--- a/app/providers/fallback_llm.py
+++ b/app/providers/fallback_llm.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def call_fallback(payload: dict[str, Any]) -> dict[str, Any]:
+    """Ultra-fast, deterministic fallback response."""
+    prompt = (payload or {}).get("prompt", "").strip()
+    if not prompt:
+        text = "[FALLBACK] I’m here and responsive. Try again in a moment."
+    else:
+        sample = prompt[:80].replace("\n", " ")
+        text = f"[FALLBACK] Quick tip: stay consistent. (You said: “{sample}…”)"
+    return {"text": text}

--- a/app/providers/mock_llm.py
+++ b/app/providers/mock_llm.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import random
+import time
+from typing import Any
+
+
+class ProviderTimeout(TimeoutError):
+    pass
+
+
+def call_model(payload: dict[str, Any], timeout_secs: float) -> dict[str, Any]:
+    simulated = random.uniform(0.05, 1.2)  # 50ms–1.2s latency
+    if random.random() < 0.10:  # 10% transient
+        time.sleep(min(simulated, timeout_secs))
+        raise ProviderTimeout("upstream timeout")
+    if random.random() < 0.05:  # 5% hard failure
+        raise ValueError("non-transient parse error")
+
+    if simulated > timeout_secs:  # honor timeout
+        time.sleep(timeout_secs)
+        raise ProviderTimeout("timeout exceeded")
+
+    time.sleep(simulated)
+    prompt = payload.get("prompt", "")
+    return {"text": f"[MOCK COMPLETION] {prompt[:60]}"}

--- a/app/safety/generate_router.py
+++ b/app/safety/generate_router.py
@@ -1,0 +1,46 @@
+# app/safety/generate_router.py
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.infra.llm_client import LLMClient
+from app.providers.mock_llm import call_model as mock_call_model  # swap to real later
+
+log = logging.getLogger("persona_lab.generate")
+router = APIRouter(tags=["safety"])
+
+# Single shared client instance
+llm = LLMClient(fn_call_model=mock_call_model)
+
+
+class GenerateRequest(BaseModel):
+    prompt: str
+
+
+class GenerateResponse(BaseModel):
+    text: str
+    meta: dict
+
+
+@router.post("/generate_v2", response_model=GenerateResponse)
+def safety_generate(req: GenerateRequest):
+    """
+    Milestone 9A — resilient generation:
+      - per-call timeout
+      - bounded retries (transient only)
+      - circuit breaker with half-open probes
+    """
+    result = llm.call({"prompt": req.prompt})
+
+    if not result["ok"]:
+        meta = result.get("meta", {})
+        err = result.get("error", "unknown_error")
+        # 9B will add graceful fallback; for now surface a clean 503.
+        raise HTTPException(status_code=503, detail={"error": err, "meta": meta})
+
+    meta = result["meta"]
+    text = result["result"]["text"]
+    return GenerateResponse(text=text, meta=meta)

--- a/app/safety/generate_router.py
+++ b/app/safety/generate_router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Header
 from pydantic import BaseModel
 
 from app.infra.llm_client import LLMClient
+from app.infra.metrics import metrics  # NEW: observability
 from app.infra.ttl_cache import TTLCache
 from app.providers.fallback_llm import call_fallback  # ultra-fast deterministic fallback
 from app.providers.mock_llm import call_model as mock_call_model  # primary (swap to real later)
@@ -45,13 +46,13 @@ def safety_generate(
     idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
 ):
     """
-    Milestone 9B + 9C — Fallback + Lightweight Cache & Idempotency
+    9B + 9C + 9D — Fallback + Cache/Idempotency + Metrics
       1) Derive stable cache key (Idempotency-Key header if present, else SHA-256 of prompt).
-      2) Return cached response if present (source=cache_hit).
+      2) Return cached response if present (source=cache_hit) and record metrics.
       3) Try primary via LLMClient (timeout + retries + circuit breaker).
-      4) If primary fails => return fallback (source=fallback_error) and cache it.
-      5) If primary succeeds but exceeds latency budget => return fallback (source=fallback_latency_budget) and cache it.
-      6) Otherwise => return primary (source=primary) and cache it.
+      4) If primary fails => return fallback and record metrics (source=fallback_error).
+      5) If primary succeeds but exceeds latency budget => return fallback and record metrics (source=fallback_latency_budget).
+      6) Otherwise => return primary and record metrics (source=primary).
     """
     payload = {"prompt": req.prompt}
 
@@ -65,16 +66,27 @@ def safety_generate(
     # 2) Cache lookup
     cached = cache.get(key)
     if cached:
-        # IMPORTANT: don't let cached meta overwrite our "cache_hit" source
+        # Keep source explicit; nest original meta to avoid overwriting
+        cached_meta = cached["meta"]
+        # If we cached a primary/fallback result earlier, we can optionally propagate its latency
+        cached_elapsed = None
+        if isinstance(cached_meta, dict):
+            orig = cached_meta.get("primary_meta") or cached_meta.get("cached") or cached_meta
+            cached_elapsed = orig.get("elapsed_ms") if isinstance(orig, dict) else None
+            cached_breaker = orig.get("breaker_state") if isinstance(orig, dict) else None
+        else:
+            cached_breaker = None
+        metrics.record(
+            "cache_hit", elapsed_ms=cached_elapsed, breaker_state=cached_breaker, attempts=None
+        )
         return GenerateResponse(
-            text=cached["text"],
-            meta=_mk_meta("cache_hit", {"cached": cached["meta"]}),
+            text=cached["text"], meta=_mk_meta("cache_hit", {"cached": cached_meta})
         )
 
     # 3) Call primary
     primary = llm.call(payload)
 
-    # 4) Failure => fallback (cache it)
+    # 4) Failure => fallback (cache it + metrics)
     if not primary["ok"]:
         meta = primary.get("meta", {})
         err = primary.get("error", "unknown_error")
@@ -84,9 +96,15 @@ def safety_generate(
             "meta": _mk_meta("fallback_error", {"primary_error": err, "primary_meta": meta}),
         }
         cache.set(key, result)
+        metrics.record(
+            "fallback_error",
+            elapsed_ms=meta.get("elapsed_ms"),
+            breaker_state=meta.get("breaker_state"),
+            attempts=meta.get("attempts"),
+        )
         return GenerateResponse(text=result["text"], meta=result["meta"])
 
-    # 5) Succeeded but over latency budget => fallback (cache it)
+    # 5) Succeeded but over latency budget => fallback (cache it + metrics)
     meta = primary["meta"]
     if llm.latency_budget_exceeded(meta):
         fb = call_fallback(payload)
@@ -95,9 +113,33 @@ def safety_generate(
             "meta": _mk_meta("fallback_latency_budget", {"primary_meta": meta}),
         }
         cache.set(key, result)
+        metrics.record(
+            "fallback_latency_budget",
+            elapsed_ms=meta.get("elapsed_ms"),
+            breaker_state=meta.get("breaker_state"),
+            attempts=meta.get("attempts"),
+        )
         return GenerateResponse(text=result["text"], meta=result["meta"])
 
-    # 6) Normal primary success (cache it)
+    # 6) Normal primary success (cache it + metrics)
     result = {"text": primary["result"]["text"], "meta": _mk_meta("primary", meta)}
     cache.set(key, result)
+    metrics.record(
+        "primary",
+        elapsed_ms=meta.get("elapsed_ms"),
+        breaker_state=meta.get("breaker_state"),
+        attempts=meta.get("attempts"),
+    )
     return GenerateResponse(text=result["text"], meta=result["meta"])
+
+
+@router.get("/inference_metrics")
+def inference_metrics():
+    """
+    JSON metrics snapshot for dashboards/demos:
+      - counters by outcome
+      - breaker states seen
+      - attempts histogram
+      - latency p50/p95/max overall and by outcome
+    """
+    return metrics.snapshot()

--- a/app/safety/generate_router.py
+++ b/app/safety/generate_router.py
@@ -1,21 +1,24 @@
 # app/safety/generate_router.py
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Header
 from pydantic import BaseModel
 
 from app.infra.llm_client import LLMClient
+from app.infra.ttl_cache import TTLCache
 from app.providers.fallback_llm import call_fallback  # ultra-fast deterministic fallback
 from app.providers.mock_llm import call_model as mock_call_model  # primary (swap to real later)
 
 log = logging.getLogger("persona_lab.generate")
 router = APIRouter(tags=["safety"])
 
-# Shared client instance (respects env knobs from .env/.env.example)
+# Shared instances
 llm = LLMClient(fn_call_model=mock_call_model)
+cache = TTLCache()
 
 
 # ---- I/O models
@@ -37,40 +40,64 @@ def _mk_meta(source: str, extra: dict[str, Any] | None = None) -> dict[str, Any]
 
 
 @router.post("/generate_v2", response_model=GenerateResponse)
-def safety_generate(req: GenerateRequest):
+def safety_generate(
+    req: GenerateRequest,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+):
     """
-    Milestone 9B — Fallback Routing
-      1) Try primary via LLMClient (timeout + retries + circuit breaker).
-      2) If primary fails => return fallback (source=fallback_error).
-      3) If primary succeeds but exceeds latency budget => return fallback (source=fallback_latency_budget).
-      4) Otherwise => return primary (source=primary).
+    Milestone 9B + 9C — Fallback + Lightweight Cache & Idempotency
+      1) Derive stable cache key (Idempotency-Key header if present, else SHA-256 of prompt).
+      2) Return cached response if present (source=cache_hit).
+      3) Try primary via LLMClient (timeout + retries + circuit breaker).
+      4) If primary fails => return fallback (source=fallback_error) and cache it.
+      5) If primary succeeds but exceeds latency budget => return fallback (source=fallback_latency_budget) and cache it.
+      6) Otherwise => return primary (source=primary) and cache it.
     """
     payload = {"prompt": req.prompt}
 
-    # 1) Call primary
+    # 1) Stable cache key
+    if idempotency_key:
+        key = f"idemp:{idempotency_key}"
+    else:
+        h = hashlib.sha256(req.prompt.encode("utf-8")).hexdigest()
+        key = f"prompt:{h}"
+
+    # 2) Cache lookup
+    cached = cache.get(key)
+    if cached:
+        # IMPORTANT: don't let cached meta overwrite our "cache_hit" source
+        return GenerateResponse(
+            text=cached["text"],
+            meta=_mk_meta("cache_hit", {"cached": cached["meta"]}),
+        )
+
+    # 3) Call primary
     primary = llm.call(payload)
 
-    # 2) On failure, serve fallback
+    # 4) Failure => fallback (cache it)
     if not primary["ok"]:
         meta = primary.get("meta", {})
         err = primary.get("error", "unknown_error")
         fb = call_fallback(payload)
-        return GenerateResponse(
-            text=fb["text"],
-            meta=_mk_meta("fallback_error", {"primary_error": err, "primary_meta": meta}),
-        )
+        result = {
+            "text": fb["text"],
+            "meta": _mk_meta("fallback_error", {"primary_error": err, "primary_meta": meta}),
+        }
+        cache.set(key, result)
+        return GenerateResponse(text=result["text"], meta=result["meta"])
 
-    # 3) If primary is slow (over latency budget), prefer fallback
+    # 5) Succeeded but over latency budget => fallback (cache it)
     meta = primary["meta"]
     if llm.latency_budget_exceeded(meta):
         fb = call_fallback(payload)
-        return GenerateResponse(
-            text=fb["text"],
-            meta=_mk_meta("fallback_latency_budget", {"primary_meta": meta}),
-        )
+        result = {
+            "text": fb["text"],
+            "meta": _mk_meta("fallback_latency_budget", {"primary_meta": meta}),
+        }
+        cache.set(key, result)
+        return GenerateResponse(text=result["text"], meta=result["meta"])
 
-    # 4) Normal success path
-    return GenerateResponse(
-        text=primary["result"]["text"],
-        meta=_mk_meta("primary", meta),
-    )
+    # 6) Normal primary success (cache it)
+    result = {"text": primary["result"]["text"], "meta": _mk_meta("primary", meta)}
+    cache.set(key, result)
+    return GenerateResponse(text=result["text"], meta=result["meta"])


### PR DESCRIPTION
## 9A Resilient LLM Client
- `circuit_breaker.py`: rolling window + half-open probe  
- `llm_client.py`: timeout, retries, latency budget, breaker state in meta  
- `mock_llm.py`: flaky mock for safe testing  

## 9B Fallback
- `fallback_llm.py`: deterministic fast fallback text  
- Router logic: fallback on primary error or latency budget breach  

## 9C Cache & Idempotency
- `ttl_cache.py`: TTL + LRU eviction  
- `generate_router.py`: SHA-256 of prompt or `Idempotency-Key` as cache key  
- Cache-hit responses labeled with `source=cache_hit` and nested original meta  

## 9D Observability
- `metrics.py`: counters, breaker state, attempts histogram, latency p50/p95/max  
- `/safety/inference_metrics` endpoint for snapshot JSON  

---

## Why It Matters
- Protects UX from upstream failures or long tail latency  
- Prevents duplicate work/cost with idempotency + caching  
- Exposes transparent metrics for tuning and debugging  
- Elevates `persona-lab` from a demo API to a production-style inference service with resilience + observability
