### PR TITLE
Milestone 10 — Monetization Experiment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,15 @@ LLM_LATENCY_BUDGET_MS=2500
 # ---- Inference Cache ----
 LLM_CACHE_TTL_SECONDS=60
 LLM_CACHE_MAX_ENTRIES=512
+
+
+# --- Monetization knobs ---
+# Master switch
+MONETIZATION_ENABLED=1
+
+# Free tier: per-client daily request cap (UTC day)
+FREE_TIER_DAILY_REQUESTS=50
+
+# Accept premium or internal plans via header for experiments (no real auth yet)
+# e.g., X-Client-Plan: PREMIUM or INTERNAL
+ALLOW_HEADER_PLANS=1

--- a/app/deps.py
+++ b/app/deps.py
@@ -1,0 +1,28 @@
+import os
+
+from fastapi import Request
+
+from app.monetization.models import MonetizationPlan
+
+
+def resolve_client(request: Request) -> tuple[str, MonetizationPlan]:
+    """
+    Resolve a (client_id, plan) tuple.
+    - Prefer explicit X-Client-ID header.
+    - Fallback to client IP (peername).
+    - Plan can be hinted via X-Client-Plan when ALLOW_HEADER_PLANS=1.
+    """
+    headers = request.headers
+    client_id = headers.get("X-Client-ID")
+    if not client_id:
+        # Fallback to peer IP (not perfect behind proxies; OK for demo)
+        client_host = request.client.host if request.client else "unknown"
+        client_id = f"ip:{client_host}"
+
+    plan = MonetizationPlan.FREE
+    if os.getenv("ALLOW_HEADER_PLANS", "0") == "1":
+        raw = headers.get("X-Client-Plan", "").upper().strip()
+        if raw in (p.value for p in MonetizationPlan):
+            plan = MonetizationPlan(raw)
+
+    return client_id, plan

--- a/app/monetization/constants.py
+++ b/app/monetization/constants.py
@@ -1,0 +1,11 @@
+# Stable exit codes
+EXIT_CAP_EXCEEDED = "MONETIZATION_CAP_EXCEEDED"
+
+# Header names (canonical)
+HDR_EXIT = "X-Monetization-Exit"
+HDR_CLIENT = "X-Monetization-Client"
+HDR_PLAN = "X-Monetization-Plan"
+HDR_RETRY_AFTER = "Retry-After"
+
+# Convenience header for allowed responses
+HDR_QUOTA_REMAINING = "X-Quota-Remaining"

--- a/app/monetization/guard.py
+++ b/app/monetization/guard.py
@@ -1,0 +1,71 @@
+import os
+import threading
+from datetime import UTC, datetime
+
+from app.monetization.models import MonetizationPlan
+
+
+class MonetizationGuard:
+    """
+    In-memory per-day request counter and plan-based caps.
+
+    NOT for multi-process or multi-instance accuracy.
+    Replace with Redis for real deployments.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._day_key = self._current_day_key()
+        # usage[(day_key, client_id)] = count
+        self._usage: dict[tuple[str, str], int] = {}
+
+    @staticmethod
+    def _current_day_key() -> str:
+        now = datetime.now(UTC)
+        return now.strftime("%Y-%m-%d")  # UTC day bucket
+
+    def _rollover_if_needed(self):
+        cur = self._current_day_key()
+        if cur != self._day_key:
+            # New UTC day; reset usage
+            self._usage = {}
+            self._day_key = cur
+
+    @staticmethod
+    def _cap_for_plan(plan: MonetizationPlan) -> int:
+        if plan in (MonetizationPlan.PREMIUM, MonetizationPlan.INTERNAL):
+            # For now, unlimited in experiments
+            return 10_000_000
+        # FREE tier from env
+        return int(os.getenv("FREE_TIER_DAILY_REQUESTS", "50"))
+
+    def check_and_increment(self, client_id: str, plan: MonetizationPlan) -> tuple[bool, int, int]:
+        """
+        Returns (allowed, usage_after, cap)
+        - If allowed is False, caller should reject with monetization exit.
+        """
+        if os.getenv("MONETIZATION_ENABLED", "0") != "1":
+            # Treat as unlimited if disabled
+            return True, 0, 10_000_000
+
+        with self._lock:
+            self._rollover_if_needed()
+            cap = self._cap_for_plan(plan)
+            key = (self._day_key, client_id)
+            current = self._usage.get(key, 0)
+            if current >= cap:
+                return False, current, cap
+            new_val = current + 1
+            self._usage[key] = new_val
+            return True, new_val, cap
+
+    def snapshot(self, client_id: str, plan: MonetizationPlan) -> tuple[int, int]:
+        """
+        Returns (usage_today, cap) without increment.
+        """
+        with self._lock:
+            self._rollover_if_needed()
+            cap = self._cap_for_plan(plan)
+            key = (self._day_key, client_id)
+            current = self._usage.get(key, 0)
+            return current, cap

--- a/app/monetization/metrics.py
+++ b/app/monetization/metrics.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections import Counter, deque
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+
+
+@dataclass
+class MonetizationEvent:
+    ts: str
+    client_id: str
+    plan: str
+    outcome: str  # e.g., "ALLOWED", "DENIED_CAP", "TEST"
+    usage: int
+    cap: int
+
+
+class MonetizationMetrics:
+    """
+    Lightweight, in-memory counters + rolling log of monetization events.
+    """
+
+    def __init__(self, max_events: int = 200):
+        self.plan_totals: Counter[str] = Counter()
+        self.client_totals: Counter[str] = Counter()
+        self.events: deque[MonetizationEvent] = deque(maxlen=max_events)
+
+    def record(
+        self,
+        client_id: str,
+        plan: str,
+        outcome: str,
+        usage: int,
+        cap: int,
+    ):
+        self.plan_totals[plan] += 1
+        self.client_totals[client_id] += 1
+        evt = MonetizationEvent(
+            ts=datetime.now(UTC).isoformat(),
+            client_id=client_id,
+            plan=plan,
+            outcome=outcome,
+            usage=usage,
+            cap=cap,
+        )
+        self.events.append(evt)
+
+    def snapshot(self) -> dict[str, object]:
+        return {
+            "plans": dict(self.plan_totals),
+            "clients_top": self.client_totals.most_common(10),
+            "recent": [asdict(e) for e in list(self.events)[-20:]],
+        }
+
+
+# Global singleton
+metrics = MonetizationMetrics()

--- a/app/monetization/models.py
+++ b/app/monetization/models.py
@@ -1,0 +1,49 @@
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class MonetizationPlan(str, Enum):
+    FREE = "FREE"
+    PREMIUM = "PREMIUM"
+    INTERNAL = "INTERNAL"
+
+
+class MonetizationStatus(BaseModel):
+    client_id: str = Field(..., description="Resolved client identifier")
+    plan: MonetizationPlan = Field(default=MonetizationPlan.FREE)
+    usage_today: int = Field(
+        ..., ge=0, description="Number of requests counted for the current UTC day"
+    )
+    daily_cap: int = Field(..., ge=0, description="Daily request cap for the resolved plan")
+    remaining_today: int = Field(..., ge=0, description="Requests left before hitting the cap")
+    as_of_utc: str = Field(..., description="Timestamp ISO-8601 in UTC")
+
+
+class MonetizationConfig(BaseModel):
+    enabled: bool
+    free_tier_daily_requests: int
+    allow_header_plans: bool
+    notes: str | None = Field(default=None, description="Freeform notes for client UX")
+
+
+class MonetizationExit(BaseModel):
+    code: str = Field(..., description="Stable, machine-readable code")
+    http_status: int = Field(..., description="HTTP status associated with this exit")
+    summary: str = Field(..., description="Human short description")
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="Canonical headers clients can expect (names only; values vary)",
+    )
+    retry_hint_utc: str | None = Field(
+        default=None,
+        description="If present, an ISO-8601 timestamp when client can retry without penalty",
+    )
+
+
+class MonetizationExitsDoc(BaseModel):
+    exits: list[MonetizationExit]
+    header_contract: dict[str, str] = Field(
+        description="Header names and meanings used across monetization exits"
+    )
+    notes: str | None = None

--- a/app/monetization/router.py
+++ b/app/monetization/router.py
@@ -1,0 +1,107 @@
+import os
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+
+from app.deps import resolve_client
+from app.monetization.guard import MonetizationGuard
+from app.monetization.models import (
+    MonetizationConfig,
+    MonetizationExit,
+    MonetizationExitsDoc,
+    MonetizationPlan,
+    MonetizationStatus,
+)
+
+router = APIRouter(prefix="/monetization", tags=["monetization"])
+
+_guard = MonetizationGuard()
+
+# Annotated dependency type for ruff B008 compliance
+ResolvedClient = Annotated[tuple[str, MonetizationPlan], Depends(resolve_client)]
+
+
+@router.get("/status", response_model=MonetizationStatus)
+def get_status(request: Request, id_and_plan: ResolvedClient):
+    client_id, plan = id_and_plan
+    usage, cap = _guard.snapshot(client_id, plan)
+    remaining = max(0, cap - usage)
+    return MonetizationStatus(
+        client_id=client_id,
+        plan=plan,
+        usage_today=usage,
+        daily_cap=cap,
+        remaining_today=remaining,
+        as_of_utc=datetime.now(UTC).isoformat(),
+    )
+
+
+@router.get("/config", response_model=MonetizationConfig)
+def get_config():
+    return MonetizationConfig(
+        enabled=(os.getenv("MONETIZATION_ENABLED", "0") == "1"),
+        free_tier_daily_requests=int(os.getenv("FREE_TIER_DAILY_REQUESTS", "50")),
+        allow_header_plans=(os.getenv("ALLOW_HEADER_PLANS", "0") == "1"),
+        notes="Header-based plan selection is for experiments only. Do not use in production.",
+    )
+
+
+@router.get("/exits", response_model=MonetizationExitsDoc)
+def get_exits_doc():
+    """
+    Documents the monetization exit taxonomy and the headers contract.
+    Keep this in sync with enforcement points (e.g., /predict_ab).
+    """
+    exits = [
+        MonetizationExit(
+            code="MONETIZATION_CAP_EXCEEDED",
+            http_status=429,
+            summary="Daily request cap reached for your plan.",
+            headers={
+                "X-Monetization-Exit": "Machine-readable exit reason",
+                "X-Monetization-Client": "Resolved client id used for metering",
+                "X-Monetization-Plan": "Resolved plan (FREE|PREMIUM|INTERNAL)",
+                "Retry-After": "Seconds until a generic retry is advisable",
+            },
+        ),
+    ]
+    header_contract = {
+        "X-Monetization-Exit": "Stable exits like CAP_EXCEEDED",
+        "X-Monetization-Client": "Echo of the metered client id",
+        "X-Monetization-Plan": "Resolved plan at time of decision",
+        "Retry-After": "Advisory seconds; true reset is next UTC midnight for FREE",
+    }
+    return MonetizationExitsDoc(
+        exits=exits,
+        header_contract=header_contract,
+        notes="For production, replace header-plans with real auth and central storage (e.g., Redis).",
+    )
+
+
+@router.post("/test", response_model=MonetizationStatus)
+def test_consume_one(request: Request, id_and_plan: ResolvedClient):
+    """
+    QA helper: consumes one unit from the guard for the resolved client/plan,
+    then returns the updated status snapshot.
+    """
+    client_id, plan = id_and_plan
+    _guard.check_and_increment(client_id, plan)
+    usage, cap = _guard.snapshot(client_id, plan)
+    return MonetizationStatus(
+        client_id=client_id,
+        plan=plan,
+        usage_today=usage,
+        daily_cap=cap,
+        remaining_today=max(0, cap - usage),
+        as_of_utc=datetime.now(UTC).isoformat(),
+    )
+
+
+def get_guard() -> MonetizationGuard:
+    """
+    For use in other routers to enforce caps:
+    from app.monetization.router import get_guard
+    allowed, used, cap = get_guard().check_and_increment(client_id, plan)
+    """
+    return _guard


### PR DESCRIPTION
Implements monetization guard and metrics layer.

**10A — Scaffold**
- Env knobs: MONETIZATION_ENABLED, FREE_TIER_DAILY_REQUESTS, ALLOW_HEADER_PLANS
- MonetizationGuard, client resolver, plan model

**10B — Enforcement**
- Integrated guard on /predict_ab
- Returns 429 + X-Monetization-* headers on cap exceeded

**10C — Reflection**
- /monetization/status for client plan/usage
- /monetization/config for env reflection
- /monetization/exits taxonomy
- /monetization/test QA endpoint

**10D — Experiment Hooks**
- /monetization/metrics endpoint
- In-memory plan/client counters and recent events

**10E — Polish**
- Centralized constants for exit codes and headers
- Success responses include X-Quota-Remaining
- README docs with curl examples and header contract

---

### QA Notes
- FREE cap defaults to 5 (configurable by env)
- PREMIUM bypass allowed only when ALLOW_HEADER_PLANS=1 (dev/test only)
- Verified with curl: quota countdown works, 429 exits return structured JSON, headers populate correctly
- Metrics endpoint shows plan/client usage and recent events
